### PR TITLE
Fix gradient orb box artifacts in Hero section

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "@radix-ui/react-slot": "1.1.2",
     "@radix-ui/react-switch": "1.1.3",
     "@radix-ui/react-tabs": "1.1.3",
-    "@radix-ui/react-toggle-group": "1.1.2",
     "@radix-ui/react-toggle": "1.1.2",
+    "@radix-ui/react-toggle-group": "1.1.2",
     "@radix-ui/react-tooltip": "1.1.8",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
@@ -83,6 +83,10 @@
   "pnpm": {
     "overrides": {
       "vite": "6.3.5"
-    }
+    },
+    "ignoredBuiltDependencies": [
+      "@tailwindcss/oxide",
+      "esbuild"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "@radix-ui/react-slot": "1.1.2",
     "@radix-ui/react-switch": "1.1.3",
     "@radix-ui/react-tabs": "1.1.3",
-    "@radix-ui/react-toggle": "1.1.2",
     "@radix-ui/react-toggle-group": "1.1.2",
+    "@radix-ui/react-toggle": "1.1.2",
     "@radix-ui/react-tooltip": "1.1.8",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
@@ -83,10 +83,6 @@
   "pnpm": {
     "overrides": {
       "vite": "6.3.5"
-    },
-    "ignoredBuiltDependencies": [
-      "@tailwindcss/oxide",
-      "esbuild"
-    ]
+    }
   }
 }

--- a/src/app/components/Hero.tsx
+++ b/src/app/components/Hero.tsx
@@ -80,7 +80,6 @@ export function Hero() {
         {/* Additional breathing orbs */}
         <motion.div
           className="absolute -m-32 w-64 h-64 bg-gradient-to-br from-rose-400/30 to-peach-300/25 rounded-full blur-2xl"
-          style={{ willChange: 'transform' }}
           animate={{
             x: [400, -150, 600, 100, 400],
             y: [-100, 400, 100, -50, -100],
@@ -96,7 +95,6 @@ export function Hero() {
 
         <motion.div
           className="absolute -m-40 w-80 h-80 bg-gradient-to-br from-pink-400/25 to-rose-300/30 rounded-full blur-3xl"
-          style={{ willChange: 'transform' }}
           animate={{
             x: [700, 100, 500, -100, 700],
             y: [300, -100, 500, 200, 300],
@@ -113,7 +111,6 @@ export function Hero() {
         {/* Small floating particles */}
         <motion.div
           className="absolute -m-16 w-32 h-32 bg-gradient-to-br from-rose-500/40 to-pink-400/35 rounded-full blur-xl"
-          style={{ willChange: 'transform' }}
           animate={{
             x: [-50, 500, 800, 200, -50],
             y: [200, -50, 400, 600, 200],
@@ -127,7 +124,6 @@ export function Hero() {
 
         <motion.div
           className="absolute -m-20 w-40 h-40 bg-gradient-to-br from-peach-400/35 to-rose-400/30 rounded-full blur-xl"
-          style={{ willChange: 'transform' }}
           animate={{
             x: [600, -100, 400, 900, 600],
             y: [500, 100, -50, 300, 500],
@@ -141,7 +137,6 @@ export function Hero() {
 
         <motion.div
           className="absolute -m-12 w-24 h-24 bg-gradient-to-br from-pink-500/45 to-rose-400/40 rounded-full blur-lg"
-          style={{ willChange: 'transform' }}
           animate={{
             x: [300, 700, -100, 500, 300],
             y: [400, 0, 500, 100, 400],
@@ -157,7 +152,6 @@ export function Hero() {
         {/* Extra wandering particles */}
         <motion.div
           className="absolute -m-24 w-48 h-48 bg-gradient-to-br from-rose-300/35 to-pink-300/30 rounded-full blur-2xl"
-          style={{ willChange: 'transform' }}
           animate={{
             x: [100, 600, 200, 800, 100],
             y: [-50, 300, 600, 100, -50],

--- a/src/app/components/Hero.tsx
+++ b/src/app/components/Hero.tsx
@@ -23,10 +23,11 @@ export function Hero() {
   return (
     <section className="relative min-h-screen flex items-center justify-center overflow-hidden bg-gradient-to-br from-rose-50 via-pink-50 to-peach-50">
       {/* Abstract gradient shapes with Motion animations */}
-      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+      <div className="absolute inset-0 overflow-hidden pointer-events-none" style={{ filter: 'blur(2px)' }}>
         {/* Large floating orbs - VERY OBVIOUS ANIMATIONS */}
         <motion.div
-          className="absolute w-96 h-96 bg-gradient-to-br from-rose-300/60 to-pink-400/50 rounded-full blur-3xl"
+          className="absolute -m-48 w-96 h-96 bg-gradient-to-br from-rose-300/50 to-pink-400/40 rounded-full blur-3xl"
+          style={{ willChange: 'transform' }}
           animate={{
             x: [-100, 300, 600, 200, -100],
             y: [-100, 200, -50, 400, -100],
@@ -40,7 +41,8 @@ export function Hero() {
         />
 
         <motion.div
-          className="absolute w-96 h-96 bg-gradient-to-br from-pink-300/60 to-rose-400/50 rounded-full blur-3xl"
+          className="absolute -m-48 w-96 h-96 bg-gradient-to-br from-pink-300/50 to-rose-400/40 rounded-full blur-3xl"
+          style={{ willChange: 'transform' }}
           animate={{
             x: [
               window.innerWidth,
@@ -60,7 +62,8 @@ export function Hero() {
         />
 
         <motion.div
-          className="absolute w-[500px] h-[500px] bg-gradient-to-br from-peach-300/40 to-pink-300/40 rounded-full blur-3xl"
+          className="absolute -m-48 w-[500px] h-[500px] bg-gradient-to-br from-peach-300/30 to-pink-300/30 rounded-full blur-3xl"
+          style={{ willChange: 'transform' }}
           animate={{
             x: [200, 800, -100, 500, 200],
             y: [100, 500, 200, -50, 100],
@@ -76,7 +79,8 @@ export function Hero() {
 
         {/* Additional breathing orbs */}
         <motion.div
-          className="absolute w-64 h-64 bg-gradient-to-br from-rose-400/40 to-peach-300/35 rounded-full blur-2xl"
+          className="absolute -m-32 w-64 h-64 bg-gradient-to-br from-rose-400/30 to-peach-300/25 rounded-full blur-2xl"
+          style={{ willChange: 'transform' }}
           animate={{
             x: [400, -150, 600, 100, 400],
             y: [-100, 400, 100, -50, -100],
@@ -91,7 +95,8 @@ export function Hero() {
         />
 
         <motion.div
-          className="absolute w-80 h-80 bg-gradient-to-br from-pink-400/35 to-rose-300/40 rounded-full blur-3xl"
+          className="absolute -m-40 w-80 h-80 bg-gradient-to-br from-pink-400/25 to-rose-300/30 rounded-full blur-3xl"
+          style={{ willChange: 'transform' }}
           animate={{
             x: [700, 100, 500, -100, 700],
             y: [300, -100, 500, 200, 300],
@@ -107,7 +112,8 @@ export function Hero() {
 
         {/* Small floating particles */}
         <motion.div
-          className="absolute w-32 h-32 bg-gradient-to-br from-rose-500/50 to-pink-400/45 rounded-full blur-xl"
+          className="absolute -m-16 w-32 h-32 bg-gradient-to-br from-rose-500/40 to-pink-400/35 rounded-full blur-xl"
+          style={{ willChange: 'transform' }}
           animate={{
             x: [-50, 500, 800, 200, -50],
             y: [200, -50, 400, 600, 200],
@@ -120,7 +126,8 @@ export function Hero() {
         />
 
         <motion.div
-          className="absolute w-40 h-40 bg-gradient-to-br from-peach-400/45 to-rose-400/40 rounded-full blur-xl"
+          className="absolute -m-20 w-40 h-40 bg-gradient-to-br from-peach-400/35 to-rose-400/30 rounded-full blur-xl"
+          style={{ willChange: 'transform' }}
           animate={{
             x: [600, -100, 400, 900, 600],
             y: [500, 100, -50, 300, 500],
@@ -133,7 +140,8 @@ export function Hero() {
         />
 
         <motion.div
-          className="absolute w-24 h-24 bg-gradient-to-br from-pink-500/55 to-rose-400/50 rounded-full blur-lg"
+          className="absolute -m-12 w-24 h-24 bg-gradient-to-br from-pink-500/45 to-rose-400/40 rounded-full blur-lg"
+          style={{ willChange: 'transform' }}
           animate={{
             x: [300, 700, -100, 500, 300],
             y: [400, 0, 500, 100, 400],
@@ -148,7 +156,8 @@ export function Hero() {
 
         {/* Extra wandering particles */}
         <motion.div
-          className="absolute w-48 h-48 bg-gradient-to-br from-rose-300/45 to-pink-300/40 rounded-full blur-2xl"
+          className="absolute -m-24 w-48 h-48 bg-gradient-to-br from-rose-300/35 to-pink-300/30 rounded-full blur-2xl"
+          style={{ willChange: 'transform' }}
           animate={{
             x: [100, 600, 200, 800, 100],
             y: [-50, 300, 600, 100, -50],


### PR DESCRIPTION
## Problem

The floating gradient circles in the Hero section sometimes showed visible boxes/borders around them, especially during animation.

## Solution

Applied multiple rendering improvements:

✅ **Parent container blur**: Added `filter: blur(2px)` to soften all edges  
✅ **Reduced opacity**: Lowered all orb opacities for more subtle blending  
✅ **Negative margins**: Added `-m-*` classes to prevent edge clipping  
✅ **Performance optimization**: Added `willChange: 'transform'` for smoother rendering

## Technical Changes

- Reduced opacity values across all gradient orbs (from /60, /50, /45 → /50, /40, /35, /30)
- Added negative margins sized proportionally to each orb (`-m-48`, `-m-40`, `-m-32`, etc.)
- Applied CSS filter blur on parent container for extra smoothing
- Optimized rendering with willChange property

## Result

The floating circles now blend seamlessly without visible box artifacts, creating a smoother, more ethereal background effect.