### PR TITLE
Add CI workflow for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Check build output
+        run: |
+          if [ ! -d "dist" ]; then
+            echo "Error: dist directory not found"
+            exit 1
+          fi
+          echo "Build successful! dist directory exists."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,6 +20,7 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 9
+          run_install: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Adds a continuous integration (CI) workflow that automatically runs on every pull request to catch build errors before merging.

## What This Does

The CI workflow runs automatically on every PR and:

✅ Checks out the code  
✅ Sets up Node.js 20 and pnpm 9  
✅ Installs dependencies with `--frozen-lockfile` (ensures lock file is up to date)  
✅ Runs `pnpm build` to verify the project builds successfully  
✅ Verifies the `dist/` directory is created  

## Benefits

🛡️ **Prevents broken builds** from being merged  
🚀 **Fast feedback** - developers know immediately if their changes break the build  
✅ **Quality gate** - PRs can't be merged if CI fails  
📦 **Dependency verification** - ensures pnpm-lock.yaml is in sync  

## Workflow Details

- **Trigger**: Runs on all pull requests to `main` branch
- **Runner**: Ubuntu latest
- **Node version**: 20.x
- **Package manager**: pnpm 9.x
- **Cache**: pnpm cache is enabled for faster runs

## Testing

This PR itself will trigger the CI workflow, so you can see it in action!