### PR TITLE
Add Netlify PR preview deployments

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -66,7 +66,7 @@ jobs:
 
           # Find and delete deployments with the PR alias
           echo "$DEPLOYS" | jq -r --arg alias "pr-$PR_NUMBER" \
-            '.[] | select(.name == $alias or .deploy_ssl_url | contains($alias)) | .id' | \
+            '.[] | select(.deploy_ssl_url | contains($alias)) | .id' | \
           while read deploy_id; do
             if [ -n "$deploy_id" ]; then
               echo "Deleting deployment: $deploy_id"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -54,6 +54,29 @@ jobs:
     if: github.event.action == 'closed'
 
     steps:
+      - name: Delete Netlify deployment
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          # Get deployments for this PR alias
+          DEPLOYS=$(curl -s -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
+            "https://api.netlify.com/api/v1/sites/$NETLIFY_SITE_ID/deploys")
+
+          # Find and delete deployments with the PR alias
+          echo "$DEPLOYS" | jq -r --arg alias "pr-$PR_NUMBER" \
+            '.[] | select(.name == $alias or .deploy_ssl_url | contains($alias)) | .id' | \
+          while read deploy_id; do
+            if [ -n "$deploy_id" ]; then
+              echo "Deleting deployment: $deploy_id"
+              curl -X DELETE -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
+                "https://api.netlify.com/api/v1/deploys/$deploy_id"
+            fi
+          done
+
+          echo "Cleanup completed"
+
       - name: Comment on PR
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,66 @@
+name: Deploy PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    if: github.event.action != 'closed'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v3.0
+        with:
+          publish-dir: './dist'
+          production-deploy: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploy from PR #${{ github.event.number }}"
+          alias: pr-${{ github.event.number }}
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+
+  cleanup-preview:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'closed'
+
+    steps:
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '✅ Preview deployment removed.'
+            })

--- a/NETLIFY_SETUP.md
+++ b/NETLIFY_SETUP.md
@@ -1,0 +1,99 @@
+# Netlify PR Preview Setup Guide
+
+This guide will help you set up Netlify for automatic PR preview deployments.
+
+## Step 1: Create a Netlify Account
+
+1. Go to [netlify.com](https://netlify.com)
+2. Sign up for a free account (you can use your GitHub account)
+
+## Step 2: Create a New Site
+
+1. In Netlify dashboard, click "Add new site" → "Import an existing project"
+2. **Important**: Choose "Deploy manually" or skip the import
+3. You'll get a **Site ID** (looks like: `abc123def-4567-8901-2345-67890abcdef1`)
+4. Save this Site ID - you'll need it later
+
+**Alternative:** Create the site via CLI (optional):
+```bash
+# Install Netlify CLI
+npm install -g netlify-cli
+
+# Login to Netlify
+netlify login
+
+# Create a new site
+netlify sites:create --name idunn-pr-previews
+```
+
+## Step 3: Get Your Netlify Auth Token
+
+1. Go to [app.netlify.com/user/applications](https://app.netlify.com/user/applications)
+2. Scroll down to "Personal access tokens"
+3. Click "New access token"
+4. Give it a name like "GitHub Actions PR Previews"
+5. Copy the token (you won't be able to see it again!)
+
+## Step 4: Add Secrets to GitHub
+
+1. Go to your GitHub repository: [github.com/arnlaugsson/idunn.is](https://github.com/arnlaugsson/idunn.is)
+2. Click **Settings** → **Secrets and variables** → **Actions**
+3. Click **"New repository secret"**
+
+Add these two secrets:
+
+### Secret 1: NETLIFY_AUTH_TOKEN
+- Name: `NETLIFY_AUTH_TOKEN`
+- Value: (paste the token from Step 3)
+
+### Secret 2: NETLIFY_SITE_ID
+- Name: `NETLIFY_SITE_ID`
+- Value: (paste the Site ID from Step 2)
+
+## Step 5: Test It Out
+
+Once the secrets are added:
+
+1. Create a test PR
+2. The preview workflow will automatically run
+3. A comment will be posted on the PR with the preview URL
+4. Preview URL format: `https://pr-{number}--idunn-pr-previews.netlify.app`
+
+## How It Works
+
+- **On PR open/update**: Builds and deploys to Netlify with alias `pr-{number}`
+- **Each PR** gets its own preview URL that updates on every commit
+- **On PR close**: Posts a cleanup message
+- **Production**: Still uses GitHub Pages at idunn.is (unchanged)
+
+## Preview URL Examples
+
+- PR #5: `https://pr-5--idunn-pr-previews.netlify.app`
+- PR #12: `https://pr-12--idunn-pr-previews.netlify.app`
+
+## Troubleshooting
+
+### "Site ID not found"
+- Double-check the `NETLIFY_SITE_ID` secret matches your site ID exactly
+- Make sure there are no extra spaces
+
+### "Authentication failed"
+- Verify the `NETLIFY_AUTH_TOKEN` is correct
+- Generate a new token if needed
+
+### Build fails
+- Check the workflow logs in GitHub Actions
+- Ensure the site builds locally with `pnpm build`
+
+## Cost
+
+Netlify's free tier includes:
+- 100 GB bandwidth/month
+- 300 build minutes/month
+- Unlimited sites
+
+This is more than enough for PR previews!
+
+## Need Help?
+
+Check the [Netlify documentation](https://docs.netlify.com/) or the workflow logs in GitHub Actions.

--- a/NETLIFY_SETUP.md
+++ b/NETLIFY_SETUP.md
@@ -23,7 +23,7 @@ npm install -g netlify-cli
 netlify login
 
 # Create a new site
-netlify sites:create --name idunn-pr-previews
+netlify sites:create --name idunnis-previews
 ```
 
 ## Step 3: Get Your Netlify Auth Token
@@ -57,7 +57,7 @@ Once the secrets are added:
 1. Create a test PR
 2. The preview workflow will automatically run
 3. A comment will be posted on the PR with the preview URL
-4. Preview URL format: `https://pr-{number}--idunn-pr-previews.netlify.app`
+4. Preview URL format: `https://pr-{number}--idunnis-previews.netlify.app`
 
 ## How It Works
 
@@ -68,8 +68,8 @@ Once the secrets are added:
 
 ## Preview URL Examples
 
-- PR #5: `https://pr-5--idunn-pr-previews.netlify.app`
-- PR #12: `https://pr-12--idunn-pr-previews.netlify.app`
+- PR #5: `https://pr-5--idunnis-previews.netlify.app`
+- PR #12: `https://pr-12--idunnis-previews.netlify.app`
 
 ## Troubleshooting
 

--- a/NETLIFY_SETUP.md
+++ b/NETLIFY_SETUP.md
@@ -63,7 +63,7 @@ Once the secrets are added:
 
 - **On PR open/update**: Builds and deploys to Netlify with alias `pr-{number}`
 - **Each PR** gets its own preview URL that updates on every commit
-- **On PR close**: Posts a cleanup message
+- **On PR close**: Deletes the Netlify deployment and posts a cleanup message
 - **Production**: Still uses GitHub Pages at idunn.is (unchanged)
 
 ## Preview URL Examples

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Iðunn Garðarsdóttir
 
+[![Netlify Status](https://api.netlify.com/api/v1/badges/2ffc3ee2-3b6d-46dc-b90f-246c784dc350/deploy-status)](https://app.netlify.com/projects/idunnis-previews/deploys)
+
 Portfolio website for Iðunn Garðarsdóttir - Icelandic language specialist, proofreader, and legal professional.
 
 ## Tech Stack
@@ -30,7 +32,13 @@ pnpm build
 
 ## Deployment
 
-This site is automatically deployed to GitHub Pages via GitHub Actions on every push to the main branch.
+### Production
+This site is automatically deployed to **GitHub Pages** via GitHub Actions on every push to the main branch.
 
 Live site: https://idunn.is
+
+### PR Previews
+Pull requests are automatically deployed to **Netlify** for preview before merging. Each PR gets its own preview URL.
+
+Preview deployments: [idunnis-previews on Netlify](https://app.netlify.com/projects/idunnis-previews/deploys)
   

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,12 @@
+[build]
+  command = "pnpm build"
+  publish = "dist"
+
+[build.environment]
+  NODE_VERSION = "20"
+  PNPM_VERSION = "9"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
## Summary

Adds automatic PR preview deployments using Netlify while keeping GitHub Pages for production.

## What This Does

Every pull request will automatically get its own preview URL:
- **PR #5**: `https://pr-5--idunn-pr-previews.netlify.app`
- **PR #12**: `https://pr-12--idunn-pr-previews.netlify.app`

## Changes

✅ **Added `netlify.toml`** - Netlify build configuration  
✅ **Added `.github/workflows/preview.yml`** - Automated preview deployments  
✅ **Added `NETLIFY_SETUP.md`** - Step-by-step setup instructions  

## How It Works

1. **On PR open/update**: Automatically builds and deploys to Netlify
2. **Unique preview URL**: Each PR gets `pr-{number}--sitename.netlify.app`
3. **Auto-updates**: Preview updates on every commit to the PR
4. **PR comments**: Bot posts the preview URL in PR comments
5. **Cleanup**: Notifies when preview is removed on PR close

## Setup Required

⚠️ **Action Required**: You need to add GitHub secrets before this will work.

See **[NETLIFY_SETUP.md](NETLIFY_SETUP.md)** for complete setup instructions.

**Quick summary:**
1. Create a free Netlify account
2. Create a new site (get the Site ID)
3. Generate a personal access token
4. Add two secrets to GitHub:
   - `NETLIFY_AUTH_TOKEN`
   - `NETLIFY_SITE_ID`

**Estimated setup time:** 5-10 minutes

## Benefits

🎯 **Preview before merge** - See exactly how changes look  
🚀 **Share with others** - Send preview link to get feedback  
✅ **Catch issues early** - Test in production-like environment  
🔄 **Auto-updates** - Preview refreshes on every commit  
💰 **Free** - Netlify free tier is more than enough  

## Architecture

- **Production** (main branch): GitHub Pages → idunn.is
- **PR Previews**: Netlify → pr-{number}--sitename.netlify.app

Production deployment is **unchanged** - GitHub Pages continues to serve idunn.is.

## Next Steps

After merging:
1. Follow the setup guide in `NETLIFY_SETUP.md`
2. Add the required GitHub secrets
3. Test with a new PR
4. Preview URLs will appear automatically!