### PR TITLE
Add Cloudflare Web Analytics tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,10 @@
       <!-- Additional SEO -->
       <meta name="author" content="Iðunn Garðarsdóttir" />
       <link rel="canonical" href="https://idunn.is/" />
+
+      <!-- Cloudflare Web Analytics -->
+      <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "2d85bd89515b4954904a20a6527c8e05"}'></script>
+      <!-- End Cloudflare Web Analytics -->
     </head>
 
     <body>


### PR DESCRIPTION
## Summary
- Adds Cloudflare Web Analytics for privacy-focused visitor tracking
- No cookies required, GDPR compliant by default
- Tracks pageviews, visitors, and basic metrics

## Changes
- Added Cloudflare Web Analytics beacon script to `index.html`

## Test plan
- [x] Deploy to production
- [x] Verify analytics appear in Cloudflare dashboard after deployment
- [x] Confirm script loads correctly in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)