### PR TITLE
Lengthen page title to optimal SEO range

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,14 +4,14 @@
     <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <title>Iðunn Garðarsdóttir - Prófarkalestur og textagerð</title>
+      <title>Iðunn Garðarsdóttir - Prófarkalestur, textagerð og ráðgjöf</title>
       <meta name="description" content="Prófarkalestur, textagerð og verkefnastjórn. Íslenskufræðingur og lögfræðingur með reynslu af fjölbreyttum verkefnum." />
 
       <!-- Open Graph / Facebook / LinkedIn -->
       <meta property="og:type" content="website" />
       <meta property="og:locale" content="is_IS" />
       <meta property="og:url" content="https://idunn.is/" />
-      <meta property="og:title" content="Iðunn Garðarsdóttir - Prófarkalestur og textagerð" />
+      <meta property="og:title" content="Iðunn Garðarsdóttir - Prófarkalestur, textagerð og ráðgjöf" />
       <meta property="og:description" content="Prófarkalestur, textagerð og verkefnastjórn. Íslenskufræðingur og lögfræðingur með reynslu af fjölbreyttum verkefnum." />
       <meta property="og:image" content="https://idunn.is/og-image.png?v=2" />
       <meta property="og:image:width" content="1200" />
@@ -21,7 +21,7 @@
       <!-- Twitter -->
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:url" content="https://idunn.is/" />
-      <meta name="twitter:title" content="Iðunn Garðarsdóttir - Prófarkalestur og textagerð" />
+      <meta name="twitter:title" content="Iðunn Garðarsdóttir - Prófarkalestur, textagerð og ráðgjöf" />
       <meta name="twitter:description" content="Prófarkalestur, textagerð og verkefnastjórn. Íslenskufræðingur og lögfræðingur með reynslu af fjölbreyttum verkefnum." />
       <meta name="twitter:image" content="https://idunn.is/og-image.png?v=2" />
 


### PR DESCRIPTION
Follow-up to #18. The title-length fix didn't make it into that merge.

Lengthens the page title from 49 → 58 chars (into the recommended 50–60 SEO band) across `<title>`, `og:title`, and `twitter:title`:

`Iðunn Garðarsdóttir - Prófarkalestur, textagerð og ráðgjöf`